### PR TITLE
Update layer.py

### DIFF
--- a/src/layer.py
+++ b/src/layer.py
@@ -24,14 +24,15 @@ def leakyReLU_derivative(x, alpha=0.01):
     return alpha if x < 0 else 1
 
 
-def lr_schedule(learning_rate, iteration):
+def lr_schedule(learning_rate, iteration): # updated code , this will fix the error 
     if iteration == 0:
+        return learning_rate
+    if (iteration >= 0) and (iteration <= 10000):
         return learning_rate
     if iteration > 10000:
         return learning_rate * 0.1
     if iteration > 30000:
         return learning_rate * 0.1
-
 
 class Convolutional:                                        # convolution layer using 3x3 filters
 


### PR DESCRIPTION
This pull request fixes the code from @AlessandroSaviolo repo named CNN from scratch , where an error occured in layer.py , i have replaced that code . the error was in a function named ' lr schedule ' where there was no conditon passed if the iteration is above than zero or below than 10,000 | this updated code in layer.py resolves the issue . 

You see , in layer.py file , the lr_schedule functon returns only learning rate when Iteration is 0 or above 10,000 , I think @AlessandroSaviolo forget to mention ' above zero or less than 10,000 ' should return learning rate also .Here is the working code ,replace it with that 'lr schedule function' in layer.py |

 ```
def lr_schedule(learning_rate, iteration):
    if iteration == 0:
        return learning_rate
    if (iteration >= 0) and (iteration <= 10000): # add this additional condition to resolve the bug
        return learning_rate
    if iteration > 10000:
        return learning_rate * 0.1
    if iteration > 30000:
        return learning_rate * 0.1
``` 
The learning rate is None because no argument was passed when the iteration is greater than 0 , So when the iteration 2nd hit , it became None and couldn't multipy with the Float value ... as @Hommus mentioned the error .... When you add an additional 'if condition' for greater than zero , it will no longer gives that error and the CNN will work completely fine. I hope my answer is clear ...